### PR TITLE
Chore/experiments with price

### DIFF
--- a/src/services/coingecko/coingecko.service.ts
+++ b/src/services/coingecko/coingecko.service.ts
@@ -9,7 +9,7 @@ export const getNativeAssetId = (chainId: string): string => {
     '137': 'matic-network',
     '42161': 'ethereum',
     '250': 'fantom',
-    '4002': 'fantom',
+    '4002': 'fantom'
   };
 
   return mapping[chainId] || 'ethereum';
@@ -22,7 +22,7 @@ export const getPlatformId = (chainId: string): string => {
     '137': 'polygon-pos',
     '42161': 'ethereum',
     '250': 'fantom',
-    '4002': 'fantom',
+    '4002': 'fantom'
   };
 
   return mapping[chainId] || 'ethereum';


### PR DESCRIPTION
The main issue was that fantom network wasn't added to coin gecko api config.
Now both fantom-testnet and fantom networks are in the config. And api service correctly creates endpoint to search for the token price.

Still prices won't appear on the fantom-testnet since coin gecko doesn't track those. However, as I checked coin gecko tracks fantom price. 
